### PR TITLE
Menerjemahkan Domain Error ke HTTP Error

### DIFF
--- a/03-auth-api/.gitignore
+++ b/03-auth-api/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 package-lock.json
 coverage/
+config/database/test.json

--- a/03-auth-api/config/database/test.json
+++ b/03-auth-api/config/database/test.json
@@ -1,7 +1,0 @@
-{
-  "user": "developer",
-  "password": "secretPassword",
-  "host": "localhost",
-  "port": "5432",
-  "database": "authapi_test"
-}

--- a/03-auth-api/src/Commons/exceptions/DomainErrorTranslator.js
+++ b/03-auth-api/src/Commons/exceptions/DomainErrorTranslator.js
@@ -1,0 +1,16 @@
+const InvariantError = require('./InvariantError');
+
+const DomainErrorTranslator = {
+  translate(error) {
+    return DomainErrorTranslator._directories[error.message] || error;
+  },
+};
+
+DomainErrorTranslator._directories = {
+  'REGISTER_USER.NOT_CONTAIN_NEEDED_PROPERTY': new InvariantError('tidak dapat membuat user baru karena properti yang dibutuhkan tidak ada'),
+  'REGISTER_USER.NOT_MEET_DATA_TYPE_SPECIFICATION': new InvariantError('tidak dapat membuat user baru karena tipe data tidak sesuai'),
+  'REGISTER_USER.USERNAME_LIMIT_CHAR': new InvariantError('tidak dapat membuat user baru karena karakter username melebihi batas limit'),
+  'REGISTER_USER.USERNAME_CONTAIN_RESTRICTED_CHARACTER': new InvariantError('tidak dapat membuat user baru karena username mengandung karakter terlarang'),
+};
+
+module.exports = DomainErrorTranslator;

--- a/03-auth-api/src/Commons/exceptions/_test/DomainErrorTranslator.test.js
+++ b/03-auth-api/src/Commons/exceptions/_test/DomainErrorTranslator.test.js
@@ -1,0 +1,22 @@
+const DomainErrorTranslator = require('../DomainErrorTranslator');
+const InvariantError = require('../InvariantError');
+
+describe('DomainErrorTranslator', () => {
+  it('should translate error correctly', () => {
+    expect(DomainErrorTranslator.translate(new Error('REGISTER_USER.NOT_CONTAIN_NEEDED_PROPERTY'))).toStrictEqual(new InvariantError('tidak dapat membuat user baru karena properti yang dibutuhkan tidak ada'));
+    expect(DomainErrorTranslator.translate(new Error('REGISTER_USER.NOT_MEET_DATA_TYPE_SPECIFICATION'))).toStrictEqual(new InvariantError('tidak dapat membuat user baru karena tipe data tidak sesuai'));
+    expect(DomainErrorTranslator.translate(new Error('REGISTER_USER.USERNAME_LIMIT_CHAR'))).toStrictEqual(new InvariantError('tidak dapat membuat user baru karena karakter username melebihi batas limit'));
+    expect(DomainErrorTranslator.translate(new Error('REGISTER_USER.USERNAME_CONTAIN_RESTRICTED_CHARACTER'))).toStrictEqual(new InvariantError('tidak dapat membuat user baru karena username mengandung karakter terlarang'));
+  });
+
+  it('should return original error when erro message is not needed to translate', () => {
+    // Arrange
+    const error = new Error('some_error_message');
+
+    // Action
+    const translatedError = DomainErrorTranslator.translate(error);
+
+    // Assert
+    expect(translatedError).toStrictEqual(error);
+  });
+});

--- a/03-auth-api/src/Infrastructures/http/_test/createServer.test.js
+++ b/03-auth-api/src/Infrastructures/http/_test/createServer.test.js
@@ -12,6 +12,20 @@ describe('HTTP Server', () => {
     await UsersTableTestHelper.cleanTable();
   });
 
+  it('should response 404 when request unregistered route', async () => {
+    // Arrange
+    const server = await createServer(container);
+
+    // Action
+    const response = await server.inject({
+      method: 'GET',
+      url: '/unregisteredRoute',
+    });
+
+    // Assert
+    expect(response.statusCode).toEqual(404);
+  });
+
   describe('when POST /users', () => {
     it('should respond 201 and persisted user', async () => {
       // Arrange
@@ -34,6 +48,144 @@ describe('HTTP Server', () => {
       expect(response.statusCode).toEqual(201);
       expect(responseJson.status).toEqual('success');
       expect(responseJson.data.addedUser).toBeDefined();
+    });
+
+    it('should response 400 when request payload not contains needed property', async () => {
+      // Arrange
+      const requestPayload = {
+        fullname: 'Eru Desu',
+        password: 'secret',
+      };
+      const server = await createServer(container);
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(400);
+      expect(responseJson.status).toEqual('fail');
+      expect(responseJson.message).toEqual('tidak dapat membuat user baru karena properti yang dibutuhkan tidak ada');
+    });
+
+    it('should response 400 when request payload not meet data type specification', async () => {
+      // Arrange
+      const requestPayload = {
+        username: 'erudev',
+        password: 'secret',
+        fullname: ['Eru Desu'],
+      };
+      const server = await createServer(container);
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(400);
+      expect(responseJson.status).toEqual('fail');
+      expect(responseJson.message).toEqual('tidak dapat membuat user baru karena tipe data tidak sesuai');
+    });
+
+    it('should response 400 when username have more than 50 character', async () => {
+      // Arrange
+      const requestPayload = {
+        username: 'erudeverudeverudeverudeverudeverudeverudeverudeverudeverudeverudeverudev',
+        password: 'secret',
+        fullname: 'Eru Desu',
+      };
+      const server = await createServer(container);
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(400);
+      expect(responseJson.status).toEqual('fail');
+      expect(responseJson.message).toEqual('tidak dapat membuat user baru karena karakter username melebihi batas limit');
+    });
+
+    it('should response 400 when username contain restricted character', async () => {
+      // Arrange
+      const requestPayload = {
+        username: 'eru dev',
+        password: 'secret',
+        fullname: 'Eru Desu',
+      };
+      const server = await createServer(container);
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(400);
+      expect(responseJson.status).toEqual('fail');
+      expect(responseJson.message).toEqual('tidak dapat membuat user baru karena username mengandung karakter terlarang');
+    });
+
+    it('should response 400 when username unavailable', async () => {
+      // Arrange
+      await UsersTableTestHelper.addUser({ username: 'erudev' });
+      const requestPayload = {
+        username: 'erudev',
+        password: 'secret_password',
+        fullname: 'Eru Desu',
+      };
+      const server = await createServer(container);
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(400);
+      expect(responseJson.status).toEqual('fail');
+      expect(responseJson.message).toEqual('username tidak tersedia');
+    });
+
+    it('should handle server error correctly', async () => {
+      // Arrange
+      const requestPayload = {
+        username: 'erudev',
+        password: 'secret_password',
+        fullname: 'Eru Desu',
+      };
+      const server = await createServer({}); // fake container
+
+      // Action
+      const response = await server.inject({
+        method: 'POST',
+        url: '/users',
+        payload: requestPayload,
+      });
+
+      // Assert
+      const responseJson = JSON.parse(response.payload);
+      expect(response.statusCode).toEqual(500);
+      expect(responseJson.status).toEqual('error');
+      expect(responseJson.message).toEqual('terjadi kegagalan pada server');
     });
   });
 });

--- a/03-auth-api/src/Infrastructures/http/createServer.js
+++ b/03-auth-api/src/Infrastructures/http/createServer.js
@@ -1,4 +1,6 @@
 const Hapi = require('@hapi/hapi');
+const ClientError = require('../../Commons/exceptions/ClientError');
+const DomainErrorTranslator = require('../../Commons/exceptions/DomainErrorTranslator');
 const users = require('../../Interfaces/http/api/users');
 
 const createServer = async (container) => {
@@ -13,6 +15,41 @@ const createServer = async (container) => {
       options: { container },
     },
   ]);
+
+  server.ext('onPreResponse', (request, h) => {
+    // mendapatkan konteks response dari request
+    const { response } = request;
+
+    if (response instanceof Error) {
+      // bila response tersebut error, tangani sesuai kebutuhan
+      // eslint-disable-next-line no-use-before-define
+      const translatedError = DomainErrorTranslator.translate(response);
+
+      // penanganan client error secara internal.
+      if (translatedError instanceof ClientError) {
+        const newResponse = h.response({
+          status: 'fail',
+          message: translatedError.message,
+        });
+        newResponse.code(translatedError.statusCode);
+        return newResponse;
+      }
+
+      if (!translatedError.isServer) {
+        return h.continue;
+      }
+
+      const newResponse = h.response({
+        status: 'error',
+        message: 'terjadi kegagalan pada server',
+      });
+      newResponse.code(500);
+      return newResponse;
+    }
+
+    // jika bukan error, lanjutkan dengan response sebelumnya (tanpa terintervensi)
+    return h.continue;
+  });
 
   return server;
 };


### PR DESCRIPTION
- Menerjemahkan generic error yang dibangkitkan oleh domain model RegisterUser.
- Menangani eror yang dihasilkan oleh ClientError.
- Menangani eror yang terjadi secara general (server eror).
- Refactor penangan error dengan memindahkan penanganan eror pada cakupan server agar kode handler fokus pada penggunaan use case tanpa adanya penanganan eror di sana.
- Memastikan intervensi response tidak merusak behavior framework Hapi ketika mengakses endpoint yang tidak terdaftar (404 error, dll).